### PR TITLE
chore: Remove `lerna` from `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   },
   "type": "module",
   "scripts": {
-    "lerna": "lerna",
     "test": "cross-env NODE_NO_WARNINGS=1 gulp test",
     "build": "cross-env NODE_NO_WARNINGS=1 gulp build",
     "clean": "cross-env NODE_NO_WARNINGS=1 gulp clean",


### PR DESCRIPTION
## What's Changed

Removed `lerna` from `package`json` because we removed `lerna` in https://github.com/apache/arrow/pull/37393.

Closes #143.
