### PR TITLE
chore: Remove xml2js dependency

### DIFF
--- a/gulp/test-task.js
+++ b/gulp/test-task.js
@@ -28,8 +28,6 @@ const readFile = promisify(fs.readFile);
 import asyncDoneSync from 'async-done';
 const asyncDone = promisify(asyncDoneSync);
 const exec = promisify(child_process.exec);
-import xml2js from 'xml2js';
-const parseXML = promisify(xml2js.parseString);
 import { targetAndModuleCombinations, npmPkgName } from './util.js';
 import { createRequire } from 'node:module';
 

--- a/package.json
+++ b/package.json
@@ -107,8 +107,7 @@
     "web-streams-polyfill": "3.2.1",
     "webpack": "5.99.9",
     "webpack-bundle-analyzer": "4.10.2",
-    "webpack-stream": "7.0.0",
-    "xml2js": "0.6.2"
+    "webpack-stream": "7.0.0"
   },
   "engines": {
     "node": ">=12.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6066,11 +6066,6 @@ safe-regex@^1.1.0:
   dependencies:
     ret "~0.1.10"
 
-sax@>=0.6.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/sax/-/sax-1.3.0.tgz#a5dbe77db3be05c9d1ee7785dbd3ea9de51593d0"
-  integrity sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA==
-
 schema-utils@^4.3.0, schema-utils@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-4.3.2.tgz#0c10878bf4a73fd2b1dfd14b9462b26788c806ae"
@@ -7209,19 +7204,6 @@ ws@^7.3.1:
   version "7.5.10"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.10.tgz#58b5c20dc281633f6c19113f39b349bd8bd558d9"
   integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
-
-xml2js@0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.6.2.tgz#dd0b630083aa09c161e25a4d0901e2b2a929b499"
-  integrity sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==
-  dependencies:
-    sax ">=0.6.0"
-    xmlbuilder "~11.0.0"
-
-xmlbuilder@~11.0.0:
-  version "11.0.1"
-  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
-  integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
 
 xtend@~4.0.0, xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
## What's Changed

It's not used now because we removed `create:testdata`/`clean:testdata` by #147.

Closes #154.
