### PR TITLE
chore: Add shfmt and shellcheck linters

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -17,28 +15,19 @@
 # specific language governing permissions and limitations
 # under the License.
 
-set -exu
+# This is an EditorConfig file: https://editorconfig.org/
 
-source_dir="${1}"
+# This is the top-most config for this project
+root = true
 
-: "${BUILD_DOCS_JS:=OFF}"
+# General settings
 
-pushd "${source_dir}"
+[*]
+charset = utf-8
+insert_final_newline = true
+spelling_language = en
+trim_trailing_whitespace = true
 
-yarn --immutable
-yarn build
-
-if [ "${BUILD_DOCS_JS}" = "ON" ]; then
-  # If upstream is defined, use it as remote.
-  # Otherwise use origin which could be a fork on PRs.
-  if [[ "$(git config --get remote.upstream.url)" =~ https://github.com/apache/arrow-js ]]; then
-    yarn doc --gitRemote upstream
-  elif [[ "$(basename -s .git "$(git config --get remote.origin.url)")" == "arrow-js" ]]; then
-    yarn doc
-  else
-    echo "Failed to build docs because the remote is not set correctly. Please set the origin or upstream remote to https://github.com/apache/arrow-js.git."
-    exit 0
-  fi
-fi
-
-popd
+[*.sh]
+indent_size = 2
+indent_style = space

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,3 +30,20 @@ repos:
               rm -f apache-arrow-js.tar.gz"
         always_run: true
         pass_filenames: false
+  - repo: https://github.com/koalaman/shellcheck-precommit
+    rev: v0.10.0
+    hooks:
+      - id: shellcheck
+        alias: shell
+  - repo: https://github.com/scop/pre-commit-shfmt
+    # v3.11.0-1 or later requires pre-commit 3.2.0 or later but Ubuntu
+    # 22.04 ships pre-commit 2.17.0. We can use update this rev after
+    # Ubuntu 22.04 reached EOL (June 2027).
+    rev: v3.10.0-1
+    hooks:
+      - id: shfmt
+        alias: shell
+        args:
+          # The default args is "--write --simplify" but we don't use
+          # "--simplify". Because it's conflicted will ShellCheck.
+          - "--write"

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -17,28 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-set -exu
-
-source_dir="${1}"
-
-: "${BUILD_DOCS_JS:=OFF}"
-
-pushd "${source_dir}"
-
-yarn --immutable
-yarn build
-
-if [ "${BUILD_DOCS_JS}" = "ON" ]; then
-  # If upstream is defined, use it as remote.
-  # Otherwise use origin which could be a fork on PRs.
-  if [[ "$(git config --get remote.upstream.url)" =~ https://github.com/apache/arrow-js ]]; then
-    yarn doc --gitRemote upstream
-  elif [[ "$(basename -s .git "$(git config --get remote.origin.url)")" == "arrow-js" ]]; then
-    yarn doc
-  else
-    echo "Failed to build docs because the remote is not set correctly. Please set the origin or upstream remote to https://github.com/apache/arrow-js.git."
-    exit 0
-  fi
-fi
-
-popd
+external-sources=true
+source-path=SCRIPTDIR

--- a/dev/release/release.sh
+++ b/dev/release/release.sh
@@ -119,7 +119,7 @@ if [ "${RELEASE_PUBLISH}" -gt 0 ]; then
     --dir "." \
     --pattern "*.tgz" \
     --repo "${repository}"
-  read -p "Please enter your npm 2FA one-time password (or leave empty if you don't have 2FA enabled): " NPM_OTP </dev/tty
+  read -r -p "Please enter your npm 2FA one-time password (or leave empty if you don't have 2FA enabled): " NPM_OTP </dev/tty
   for package in *.tgz; do
     npm publish "${package}" "${NPM_OTP:+--otp=${NPM_OTP}}"
   done

--- a/dev/release/verify_rc.sh
+++ b/dev/release/verify_rc.sh
@@ -140,16 +140,16 @@ test_package_distributions() {
   rm -rf targets
   mkdir -p targets
   for target in apache-arrow \
-                  apache-arrow-es2015-cjs \
-                  apache-arrow-es2015-esm \
-                  apache-arrow-es2015-umd \
-                  apache-arrow-es5-cjs \
-                  apache-arrow-es5-esm \
-                  apache-arrow-es5-umd \
-                  apache-arrow-esnext-cjs \
-                  apache-arrow-esnext-esm \
-                  apache-arrow-esnext-umd \
-                  apache-arrow-ts; do
+    apache-arrow-es2015-cjs \
+    apache-arrow-es2015-esm \
+    apache-arrow-es2015-umd \
+    apache-arrow-es5-cjs \
+    apache-arrow-es5-esm \
+    apache-arrow-es5-umd \
+    apache-arrow-esnext-cjs \
+    apache-arrow-esnext-esm \
+    apache-arrow-esnext-umd \
+    apache-arrow-ts; do
     download_rc_file "${target}-${VERSION}.tgz"
     download_rc_file "${target}-${VERSION}.tgz.sha256"
     ${sha256_verify} "${target}-${VERSION}.tgz.sha256"


### PR DESCRIPTION
## What's Changed

They are shell linters. shfmt uses indent configurations in `.editorconfig`.

Closes #157.
