### PR TITLE
Fix TypeScript compilation in a Node.js environment

### DIFF
--- a/src/io/adapters.ts
+++ b/src/io/adapters.ts
@@ -26,6 +26,7 @@ import {
 import { ReadableDOMStreamOptions } from './interfaces.js';
 
 import type { ReadableOptions, Readable } from 'node:stream';
+import type { ReadableStreamReadValueResult } from 'node:stream/web';
 
 type Uint8ArrayGenerator = Generator<Uint8Array, null, { cmd: 'peek' | 'read'; size: number }>;
 type AsyncUint8ArrayGenerator = AsyncGenerator<Uint8Array, null, { cmd: 'peek' | 'read'; size: number }>;

--- a/src/io/interfaces.ts
+++ b/src/io/interfaces.ts
@@ -19,6 +19,7 @@ import streamAdapters from './adapters.js';
 
 export type { FileHandle } from 'node:fs/promises';
 import type { ReadableOptions, Readable as StreamReadable } from 'node:stream';
+import type { StreamPipeOptions } from 'node:stream/web';
 
 /** @ignore */
 export const ITERATOR_DONE: any = Object.freeze({ done: true, value: void (0) });

--- a/src/util/buffer.ts
+++ b/src/util/buffer.ts
@@ -19,6 +19,7 @@ import { encodeUtf8 } from '../util/utf8.js';
 import { TypedArray, TypedArrayConstructor, BigIntArrayConstructor } from '../interfaces.js';
 import { isPromise, isIterable, isAsyncIterable, isIteratorResult, isFlatbuffersByteBuffer } from './compat.js';
 import { ByteBuffer } from 'flatbuffers';
+import type { ReadableStreamReadResult } from 'node:stream/web';
 
 /** @ignore */
 const SharedArrayBuf = (typeof SharedArrayBuffer !== 'undefined' ? SharedArrayBuffer : ArrayBuffer);

--- a/src/util/compat.ts
+++ b/src/util/compat.ts
@@ -20,6 +20,7 @@ import { ReadableInterop, ArrowJSONLike } from '../io/interfaces.js';
 import type { ByteBuffer } from 'flatbuffers';
 import type { ReadStream } from 'node:fs';
 import type { FileHandle as FileHandle_ } from 'node:fs/promises';
+import type { UnderlyingSink } from 'node:stream/web';
 
 /** @ignore */
 type FSReadStream = ReadStream;

--- a/src/util/utf8.ts
+++ b/src/util/utf8.ts
@@ -17,7 +17,7 @@
 
 const decoder = new TextDecoder('utf-8');
 /** @ignore */
-export const decodeUtf8 = (buffer?: BufferSource) => decoder.decode(buffer);
+export const decodeUtf8 = (buffer?: Parameters<InstanceType<typeof TextDecoder>['decode']>[0]) => decoder.decode(buffer);
 
 const encoder = new TextEncoder();
 /** @ignore */

--- a/tsconfig/tsconfig.base.json
+++ b/tsconfig/tsconfig.base.json
@@ -11,7 +11,7 @@
 
     /* Basic stuff */
     "moduleResolution": "Node",
-    "lib": ["DOM", "ESNext", "ESNext.AsyncIterable"],
+    "lib": ["ESNext", "ESNext.AsyncIterable"],
 
     /* Control what is emitted */
     "declaration": true,


### PR DESCRIPTION
Fixes https://github.com/apache/arrow-js/issues/45

This library runs in modern browsers, but is also intended for use in maintained versions of Node.js, which means that the TypeScript types cannot assume `"lib": ["DOM"]`.

This change removes this `lib`, and updates the types to compile.

Given that this library runs in the browser, it feels strange to import types from `node`, but this is no worse than the current situation, which already contains imports from `node`.
