### PR TITLE
chore: Use apache/arrow-dotnet for integration test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -175,6 +175,11 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           path: js
+      - name: Checkout Arrow .NET
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          repository: apache/arrow-dotnet
+          path: dotnet
       - name: Free up disk space
         run: |
           ci/scripts/util_free_space.sh
@@ -196,6 +201,7 @@ jobs:
           archery docker run \
             -e ARCHERY_DEFAULT_BRANCH=main \
             -e ARCHERY_INTEGRATION_TARGET_IMPLEMENTATIONS=js \
+            -e ARCHERY_INTEGRATION_WITH_DOTNET=1 \
             -e ARCHERY_INTEGRATION_WITH_GO=1 \
             -e ARCHERY_INTEGRATION_WITH_JAVA=1 \
             -e ARCHERY_INTEGRATION_WITH_JS=1 \


### PR DESCRIPTION
## What's Changed

The .NET implementation is extracted to apache/arrow-dotnet.

Closes #268.
