### PR TITLE
chore: Use issue type for bug report and feature request

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -17,7 +17,7 @@
 
 name: Bug Report
 description: File a bug report
-labels: ["Type: bug"]
+type: Bug
 assignees: []
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -17,7 +17,7 @@
 
 name: Enhancement Request
 description: Request an enhancement to the project
-labels: ["Type: enhancement"]
+type: Feature
 assignees: []
 body:
   - type: markdown


### PR DESCRIPTION
## What's Changed

We don't need to reinvent issue type by issue label.

Closes #259.
