### PR TITLE
Implement Jupyter integration

### DIFF
--- a/src/table.ts
+++ b/src/table.ts
@@ -43,6 +43,9 @@ import { DataProps } from './data.js';
 import { clampRange, wrapIndex } from './util/vector.js';
 import { ArrayDataType, BigIntArray, TypedArray, TypedArrayDataType } from './interfaces.js';
 import { RecordBatch, _InternalEmptyPlaceholderRecordBatch } from './recordbatch.js';
+import { escapeHTML } from './util/html.js';
+
+const jupyterDisplay = Symbol.for("Jupyter.display");
 
 /** @ignore */
 export interface Table<T extends TypeMap = any> {
@@ -393,6 +396,46 @@ export class Table<T extends TypeMap = any> {
         (proto as any)['indexOf'] = wrapChunkedIndexOf(indexOfVisitor.getVisitFn(Type.Struct));
         return 'Table';
     })(Table.prototype);
+
+    /**
+     * Render the table as HTML table element.
+     */
+    public toHTML(): string {
+        let htmlTable = "<table>";
+
+        // Add table headers
+        htmlTable += "<thead><tr>";
+        for (const field of this.schema.fields) {
+          htmlTable += `<th>${escapeHTML(field.name)}</th>`;
+        }
+        htmlTable += "</tr></thead>";
+        // Add table data
+        htmlTable += "<tbody>";
+        for (const row of this) {
+            htmlTable += "<tr>";
+            for (const field of row.toArray()) {
+                htmlTable += `<td>${escapeHTML(String(field))}</td>`;
+            }
+            htmlTable += "</tr>";
+        }
+        htmlTable += "</tbody></table>";
+
+        return htmlTable;
+    }
+
+    /**
+     * Jupyter rich content output.
+     * @see https://docs.deno.com/runtime/reference/cli/jupyter/#rich-content-output
+     */
+    public [jupyterDisplay]() {
+        // TODO: from env or options
+        const rows = 50
+        const limited = this.slice(0, rows);
+        return {
+            // TODO: application/vnd.dataresource+json
+            "text/html": limited.toHTML()
+        }
+    }
 }
 
 

--- a/src/util/html.ts
+++ b/src/util/html.ts
@@ -1,0 +1,15 @@
+const rawMap = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;'
+} as const;
+
+
+/**
+ * Escapes text for safe interpolation into HTML.
+ */
+export function escapeHTML(str: string) {
+    return str.replace(/[&<>"']/g, (char) => rawMap[char as keyof typeof rawMap]);
+}

--- a/test/unit/table-tests.ts
+++ b/test/unit/table-tests.ts
@@ -24,7 +24,8 @@ import {
     Schema, Field, Table, RecordBatch,
     Vector, builderThroughIterable,
     Float32, Int32, Dictionary, Utf8, Int8,
-    tableFromIPC, tableToIPC, vectorFromArray
+    tableFromIPC, tableToIPC, vectorFromArray,
+    tableFromJSON
 } from 'apache-arrow';
 
 const deepCopy = (t: Table) => tableFromIPC(tableToIPC(t));
@@ -305,6 +306,14 @@ describe(`Table`, () => {
         compareBatchAndTable(table, 0, batch1, deepCopy(new Table([batch1])));
         compareBatchAndTable(table, m, batch2, deepCopy(new Table([batch2])));
     });
+
+    test(`table.toHTML() create right HTML table`, () => {
+        const table = tableFromJSON([{name: "Alice", age: 30}, {name: "Bob", age: 32}])
+        const html = table.toHTML()
+        const expected = `<table><thead><tr><th>name</th><th>age></th></tr></thead><tbody><tr><td>Alice</td><td>30</td></tr><tr><td>Bob</td><td>32</td></tr></tbody></table>`
+
+        expect(html).toEqual(expected)
+    })
 
     for (const datum of test_data) {
         describe(datum.name, () => {


### PR DESCRIPTION
## What's Changed

This pull request implements Jupyter integration for arrow-js, including the following two mime type:

- [x] `text/html`
- [ ] `application/vnd.dataresource+json`

This implementation basically follows `nodejs-polars`'s [implementation](https://github.com/pola-rs/nodejs-polars/blob/13181a13fc7f1b0515f7298b122b67dc1ea62847/polars/dataframe.ts#L2197-L2208).

Closes #245.
