### PR TITLE
fix: Fix precision loss in IntervalMonthDayNano nanosecond

### DIFF
--- a/src/util/interval.ts
+++ b/src/util/interval.ts
@@ -46,8 +46,10 @@ export function toIntervalMonthDayNanoInt32Array(objects: Partial<IntervalMonthD
         data[ai++] = interval['days'] ?? 0;
         const nanoseconds = interval['nanoseconds'];
         if (nanoseconds) {
-            data[ai++] = Number(BigInt(nanoseconds) & BigInt(0xFFFFFFFF));
-            data[ai++] = Number(BigInt(nanoseconds) >> BigInt(32));
+            const ns = BigInt(nanoseconds);
+            // Convert to unsigned 32-bit integers to avoid precision loss
+            data[ai++] = Number(ns & BigInt(0xFFFFFFFF)) >>> 0;
+            data[ai++] = Number(ns >> BigInt(32)) >>> 0;
         } else {
             ai += 2;
         }


### PR DESCRIPTION
## Rationale for this change

Integration tests were failing when JavaScript produced IntervalMonthDayNano data that was consumed by C++, Rust, or nanoarrow implementations. The nanosecond values differed by small amounts (e.g., 216 nanoseconds) due to precision loss during BigInt to Number conversion.

**Example failure:**
- Expected: `6684525287992311000ns`
- JS Output: `6684525287992310784ns`
- Difference: 216ns

## What changes are included in this PR?

Fixed the `toIntervalMonthDayNanoInt32Array` function in `src/util/interval.ts` to properly handle unsigned 32-bit integer conversion without precision loss. The issue was that `Number(BigInt)` conversion for large values (>2^53-1) loses precision. Applied unsigned right shift (`>>> 0`) to ensure correct unsigned 32-bit representation.

**Changed:**
```typescript
// Before (loses precision):
data[ai++] = Number(BigInt(nanoseconds) & BigInt(0xFFFFFFFF));
data[ai++] = Number(BigInt(nanoseconds) >> BigInt(32));

// After (preserves precision):
const ns = BigInt(nanoseconds);
data[ai++] = Number(ns & BigInt(0xFFFFFFFF)) >>> 0;
data[ai++] = Number(ns >> BigInt(32)) >>> 0;
```

Fixes apache/arrow#46203

Closes #15.