### PR TITLE
feat: Add Schema and Field withMetadata methods for metadata replacement

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -74,10 +74,9 @@ export class Schema<T extends TypeMap = any> {
      *
      * @param metadata Replacement metadata entries. Pass `null` to clear.
      */
-    public withMetadata(metadata?: Map<string, string> | Record<string, string> | null): Schema<T> {
-        if (metadata === undefined) { return this; }
+    public withMetadata(metadata: Map<string, string> | Record<string, string> | null): Schema<T> {
         const next = metadata === null ? new Map<string, string>() : toMetadataMap(metadata);
-        return new Schema<T>(this.fields, next, this.dictionaries, this.metadataVersion);
+        return new Schema<T>(this.fields, next, undefined, this.metadataVersion);
     }
 
     public assign<R extends TypeMap = any>(schema: Schema<R>): Schema<T & R>;
@@ -161,8 +160,7 @@ export class Field<T extends DataType = any> {
      *
      * @param metadata Replacement metadata entries.
      */
-    public withMetadata(metadata?: Map<string, string> | Record<string, string> | null): Field<T> {
-        if (metadata === undefined) { return this; }
+    public withMetadata(metadata: Map<string, string> | Record<string, string> | null): Field<T> {
         const next = metadata === null ? new Map<string, string>() : toMetadataMap(metadata);
         return new Field<T>(this.name, this.type, this.nullable, next);
     }

--- a/test/unit/schema-tests.ts
+++ b/test/unit/schema-tests.ts
@@ -21,16 +21,33 @@ import { Field, Int32, Schema } from 'apache-arrow';
 describe('Field.withMetadata', () => {
     test('replaces metadata from plain objects', () => {
         const field = new Field('col', new Int32(), true, new Map([['foo', 'bar']]));
-        const updated = field.withMetadata({ baz: 'qux' });
+        const input = { baz: 'qux' };
+        const updated = field.withMetadata(input);
         expect(updated).not.toBe(field);
         expect(updated.metadata.get('foo')).toBeUndefined();
         expect(updated.metadata.get('baz')).toBe('qux');
+        expect(field.metadata.get('foo')).toBe('bar');
+        expect(field.metadata.get('baz')).toBeUndefined();
+        // Mutating the input after the call should not affect the result
+        input.baz = 'changed';
+        (input as any).newKey = 'newValue';
+        expect(updated.metadata.get('baz')).toBe('qux');
+        expect(updated.metadata.get('newKey')).toBeUndefined();
     });
 
     test('replaces metadata from Maps', () => {
         const field = new Field('col', new Int32(), true, new Map([['foo', 'bar']]));
-        const updated = field.withMetadata(new Map([['foo', 'baz']]));
+        const input = new Map([['foo', 'baz']]);
+        const updated = field.withMetadata(input);
         expect(updated.metadata.get('foo')).toBe('baz');
+        expect(updated.metadata.size).toBe(1);
+        expect(field.metadata.get('foo')).toBe('bar');
+        expect(field.metadata.size).toBe(1);
+        // Mutating the input after the call should not affect the result
+        input.set('foo', 'qux');
+        input.set('newKey', 'newValue');
+        expect(updated.metadata.get('foo')).toBe('baz');
+        expect(updated.metadata.get('newKey')).toBeUndefined();
         expect(updated.metadata.size).toBe(1);
     });
 
@@ -38,23 +55,41 @@ describe('Field.withMetadata', () => {
         const field = new Field('col', new Int32(), true, new Map([['foo', 'bar']]));
         const updated = field.withMetadata(null);
         expect(updated.metadata.size).toBe(0);
+        expect(field.metadata.get('foo')).toBe('bar');
+        expect(field.metadata.size).toBe(1);
     });
 });
 
 describe('Schema.withMetadata', () => {
     test('replaces metadata from plain objects', () => {
         const schema = new Schema([new Field('col', new Int32())], new Map([['foo', 'bar']]));
-        const updated = schema.withMetadata({ baz: 'qux' });
+        const input = { baz: 'qux' };
+        const updated = schema.withMetadata(input);
         expect(updated).not.toBe(schema);
         expect(schema.metadata.get('baz')).toBeUndefined();
+        expect(schema.metadata.get('foo')).toBe('bar');
         expect(updated.metadata.get('foo')).toBeUndefined();
         expect(updated.metadata.get('baz')).toBe('qux');
+        // Mutating the input after the call should not affect the result
+        input.baz = 'changed';
+        (input as any).newKey = 'newValue';
+        expect(updated.metadata.get('baz')).toBe('qux');
+        expect(updated.metadata.get('newKey')).toBeUndefined();
     });
 
     test('replaces metadata from Maps', () => {
         const schema = new Schema([new Field('col', new Int32())], new Map([['foo', 'bar']]));
-        const updated = schema.withMetadata(new Map([['foo', 'baz']]));
+        const input = new Map([['foo', 'baz']]);
+        const updated = schema.withMetadata(input);
         expect(updated.metadata.get('foo')).toBe('baz');
+        expect(updated.metadata.size).toBe(1);
+        expect(schema.metadata.get('foo')).toBe('bar');
+        expect(schema.metadata.size).toBe(1);
+        // Mutating the input after the call should not affect the result
+        input.set('foo', 'qux');
+        input.set('newKey', 'newValue');
+        expect(updated.metadata.get('foo')).toBe('baz');
+        expect(updated.metadata.get('newKey')).toBeUndefined();
         expect(updated.metadata.size).toBe(1);
     });
 
@@ -62,5 +97,7 @@ describe('Schema.withMetadata', () => {
         const schema = new Schema([new Field('col', new Int32())], new Map([['foo', 'bar']]));
         const updated = schema.withMetadata(null);
         expect(updated.metadata.size).toBe(0);
+        expect(schema.metadata.get('foo')).toBe('bar');
+        expect(schema.metadata.size).toBe(1);
     });
 });


### PR DESCRIPTION
## What's Changed

  Summary:

- Added `Field.withMetadata()` and `Schema.withMetadata()` so callers can replace or clear metadata maps without manually juggling Map<string,string> instances. Both helpers accept either a Map, a plain object, or null (to clear), and always return a new instance, matching the C++/PyArrow/Rust behavior.
- Added `test/unit/schema-tests.ts` with coverage for the new helpers. I couldn't find a better place to put these but let me know if I missed something.

Closes https://github.com/apache/arrow-js/issues/333
