### PR TITLE
chore: Use relative link for LICENSE.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Full list of broader Apache Arrow [projects & organizations](https://arrow.apach
 
 ## License
 
-[Apache 2.0](https://github.com/apache/arrow-js/blob/main/LICENSE.txt)
+[Apache 2.0](LICENSE.txt)
 
 [1]: mailto:dev-subscribe@arrow.apache.org
 [2]: https://github.com/apache/arrow/tree/main/format


### PR DESCRIPTION
Relative link is better because it works with all branches.