### PR TITLE
fix: Resolve TS2352 type error in MapBuilder for TypeScript 5.6+

### DIFF
--- a/src/builder/map.ts
+++ b/src/builder/map.ts
@@ -32,9 +32,9 @@ export class MapBuilder<K extends DataType = any, V extends DataType = any, TNul
     }
 
     public setValue(index: number, value: MapValueExt<K, V>) {
-        const row = (value instanceof Map ? value : new Map(Object.entries(value))) as MapValue<K, V>;
+        const row = (value instanceof Map ? value : new Map(Object.entries(value))) as unknown as MapValue<K, V>;
         const pending = this._pending || (this._pending = new Map() as MapValues<K, V>);
-        const current = pending.get(index) as Map<K, V> | undefined;
+        const current = pending.get(index);
         current && (this._pendingLength -= current.size);
         this._pendingLength += row.size;
         pending.set(index, row);


### PR DESCRIPTION
## What's Changed

Fixed TS2352 type conversion error in MapBuilder.setValue() that occurs with TypeScript 5.6+ due to stricter type checking.

Changes

Updated type assertion in [map.ts] to use intermediate unknown cast (as unknown as MapValue<K, V>) to satisfy TypeScript 5.6+ stricter type narrowing
Removed unnecessary type assertion on pending.get(index) since the type is already inferred correctly

Why
TypeScript 5.6 introduced stricter type conversion rules, causing TS2352 errors when directly casting between incompatible types. The as unknown as T pattern is the recommended approach for these scenarios.

This is a non-breaking change - it only affects compile-time behavior and has no runtime impact.

Closes #49 .
