### PR TITLE
feat: add schema parameter to tableFromArrays and new recordBatchFromArrays factory

### DIFF
--- a/src/Arrow.dom.ts
+++ b/src/Arrow.dom.ts
@@ -74,7 +74,7 @@ export {
     tableFromIPC, tableToIPC,
     MessageReader, AsyncMessageReader, JSONMessageReader,
     Message,
-    RecordBatch,
+    RecordBatch, recordBatchFromArrays,
     util,
     Builder, makeBuilder, builderThroughIterable, builderThroughAsyncIterable,
     compressionRegistry, CompressionType,

--- a/src/Arrow.ts
+++ b/src/Arrow.ts
@@ -99,7 +99,7 @@ export { compressionRegistry } from './ipc/compression/registry.js';
 export type { Codec } from './ipc/compression/registry.js';
 export { MessageReader, AsyncMessageReader, JSONMessageReader } from './ipc/message.js';
 export { Message } from './ipc/metadata/message.js';
-export { RecordBatch } from './recordbatch.js';
+export { RecordBatch, recordBatchFromArrays } from './recordbatch.js';
 export type { ArrowJSONLike, FileHandle, Readable, Writable, ReadableWritable, ReadableDOMStreamOptions } from './io/interfaces.js';
 
 export {

--- a/src/recordbatch.ts
+++ b/src/recordbatch.ts
@@ -21,6 +21,8 @@ import { Vector } from './vector.js';
 import { Schema, Field } from './schema.js';
 import { DataType, Struct, Null, TypeMap } from './type.js';
 import { wrapIndex } from './util/vector.js';
+import { vectorFromArray } from './factories.js';
+import { ArrayDataType, BigIntArray, TypedArray } from './interfaces.js';
 
 import { instance as getVisitor } from './visitor/get.js';
 import { instance as setVisitor } from './visitor/set.js';
@@ -306,6 +308,61 @@ Object.defineProperty(RecordBatch, Symbol.hasInstance, {
     },
 });
 
+/**
+ * Creates a new RecordBatch from an object of typed arrays or JavaScript arrays.
+ *
+ * @example
+ * ```ts
+ * const batch = recordBatchFromArrays({
+ *   a: [1, 2, 3],
+ *   b: new Int8Array([1, 2, 3]),
+ * });
+ * ```
+ *
+ * @example
+ * ```ts
+ * const schema = new Schema([
+ *   new Field('a', new Int32),
+ *   new Field('b', new Utf8),
+ * ]);
+ * const batch = recordBatchFromArrays({ a: [1, 2, 3], b: ['x', 'y', 'z'] }, schema);
+ * ```
+ *
+ * @param input An object mapping column names to typed arrays or JavaScript arrays.
+ * @param schema Optional schema to control column types, ordering, nullability, and metadata.
+ * @returns A new RecordBatch.
+ */
+export function recordBatchFromArrays<T extends TypeMap>(
+    input: Record<string, TypedArray | BigIntArray | readonly unknown[]>,
+    schema: Schema<T>
+): RecordBatch<T>;
+export function recordBatchFromArrays<I extends Record<string | number | symbol, TypedArray | BigIntArray | readonly unknown[]>>(
+    input: I
+): RecordBatch<{ [P in keyof I]: ArrayDataType<I[P]> }>;
+export function recordBatchFromArrays(
+    input: Record<string, TypedArray | BigIntArray | readonly unknown[]>,
+    schema?: Schema
+): RecordBatch {
+    if (schema) {
+        const children: Data[] = [];
+        for (const field of schema.fields) {
+            const col = input[field.name];
+            if (col === undefined) {
+                throw new TypeError(
+                    `Schema field "${field.name}" not found in input. ` +
+                    `Available keys: [${Object.keys(input).join(', ')}]`
+                );
+            }
+            children.push(vectorFromArray(col as any, field.type).data[0]);
+        }
+        return new RecordBatch(schema, makeData({ type: new Struct(schema.fields), children }));
+    }
+    const dataMap: Record<string, Data> = {};
+    for (const [key, col] of Object.entries(input)) {
+        dataMap[key] = vectorFromArray(col).data[0];
+    }
+    return new RecordBatch(dataMap as any);
+}
 
 /** @ignore */
 function ensureSameLengthData<T extends TypeMap = any>(

--- a/test/unit/table/table-test.ts
+++ b/test/unit/table/table-test.ts
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Bool, Dictionary, Float32, Float64, Int32, Int8, makeTable, tableFromArrays, tableFromJSON } from 'apache-arrow';
+import { Bool, DataType, Dictionary, Float32, Float64, Int32, Int8, Utf8, Schema, Field, makeTable, tableFromArrays, tableFromJSON, tableToIPC, tableFromIPC, Type } from 'apache-arrow';
 
 describe('makeTable()', () => {
     test(`creates a new Table from Typed Arrays`, () => {
@@ -58,6 +58,172 @@ describe('tableFromArrays()', () => {
     });
 });
 
+
+describe('tableFromArrays() with schema', () => {
+    test(`schema overrides number inference to Int32`, () => {
+        const schema = new Schema([new Field('a', new Int32)]);
+        const table = tableFromArrays({ a: [1, 2, 3] }, schema);
+        expect(table.getChild('a')!.type).toBeInstanceOf(Int32);
+        expect(table.numRows).toBe(3);
+        expect(table.getChild('a')!.toArray()).toEqual(new Int32Array([1, 2, 3]));
+    });
+
+    test(`schema overrides string inference to Utf8`, () => {
+        const schema = new Schema([new Field('b', new Utf8)]);
+        const table = tableFromArrays({ b: ['a', 'b'] }, schema);
+        expect(table.getChild('b')!.type).toBeInstanceOf(Utf8);
+        expect(table.numRows).toBe(2);
+        expect(table.getChild('b')!.get(0)).toBe('a');
+        expect(table.getChild('b')!.get(1)).toBe('b');
+    });
+
+    test(`schema coerces TypedArray type`, () => {
+        const schema = new Schema([new Field('a', new Int32)]);
+        const table = tableFromArrays({ a: new Float32Array([1, 2, 3]) }, schema);
+        expect(table.getChild('a')!.type).toBeInstanceOf(Int32);
+        expect(table.getChild('a')!.toArray()).toEqual(new Int32Array([1, 2, 3]));
+    });
+
+    test(`preserves schema-level metadata`, () => {
+        const schema = new Schema(
+            [new Field('a', new Int32)],
+            new Map([['source', 'test']])
+        );
+        const table = tableFromArrays({ a: [1, 2, 3] }, schema);
+        expect(table.schema.metadata.get('source')).toBe('test');
+    });
+
+    test(`preserves field-level metadata`, () => {
+        const schema = new Schema([
+            new Field('a', new Int32, true, new Map([['unit', 'm']]))
+        ]);
+        const table = tableFromArrays({ a: [1, 2, 3] }, schema);
+        expect(table.schema.fields[0].metadata.get('unit')).toBe('m');
+    });
+
+    test(`preserves field ordering from schema`, () => {
+        const schema = new Schema([
+            new Field('b', new Float64),
+            new Field('a', new Int32),
+        ]);
+        const table = tableFromArrays({ a: [1, 2, 3], b: [4.0, 5.0, 6.0] }, schema);
+        expect(table.schema.fields[0].name).toBe('b');
+        expect(table.schema.fields[1].name).toBe('a');
+        expect(table.getChild('b')!.type).toBeInstanceOf(Float64);
+        expect(table.getChild('a')!.type).toBeInstanceOf(Int32);
+    });
+
+    test(`throws on missing schema field`, () => {
+        const schema = new Schema([new Field('c', new Int32)]);
+        expect(() => tableFromArrays({ a: [1] }, schema)).toThrow(TypeError);
+        expect(() => tableFromArrays({ a: [1] }, schema)).toThrow(/Schema field "c" not found in input/);
+    });
+
+    test(`ignores extra input keys not in schema`, () => {
+        const schema = new Schema([new Field('a', new Int32)]);
+        const table = tableFromArrays({ a: [1, 2], b: [3, 4] }, schema);
+        expect(table.numCols).toBe(1);
+        expect(table.schema.fields[0].name).toBe('a');
+    });
+
+    test(`preserves nullability`, () => {
+        const schema = new Schema([new Field('a', new Int32, false)]);
+        const table = tableFromArrays({ a: [1, 2, 3] }, schema);
+        expect(table.schema.fields[0].nullable).toBe(false);
+    });
+
+    test(`handles null values in input`, () => {
+        const schema = new Schema([new Field('a', new Int32, true)]);
+        const table = tableFromArrays({ a: [1, null, 3] }, schema);
+        expect(table.numRows).toBe(3);
+        expect(table.getChild('a')!.nullCount).toBeGreaterThan(0);
+    });
+
+    test(`BigInt boundary throws for BigInt64Array to Int32`, () => {
+        const schema = new Schema([new Field('a', new Int32)]);
+        expect(() => tableFromArrays({ a: new BigInt64Array([1n, 2n]) }, schema)).toThrow(TypeError);
+        expect(() => tableFromArrays({ a: new BigInt64Array([1n, 2n]) }, schema)).toThrow(/BigInt/);
+    });
+
+    test(`handles empty arrays`, () => {
+        const schema = new Schema([new Field('a', new Int32)]);
+        const table = tableFromArrays({ a: new Int32Array(0) }, schema);
+        expect(table.numRows).toBe(0);
+        expect(table.numCols).toBe(1);
+        expect(table.getChild('a')!.type).toBeInstanceOf(Int32);
+    });
+});
+
+describe('tableFromArrays() with schema IPC round-trip', () => {
+    const schema = new Schema([
+        new Field('b', new Utf8),
+        new Field('a', new Int32, true, new Map([['unit', 'meters']])),
+        new Field('c', new Int8),
+    ], new Map([['source', 'test']]));
+
+    // Input key order differs from schema field order
+    const input = {
+        a: [1, null, 3],
+        b: ['x', 'y', 'z'],
+        c: new Float32Array([10, 20, 30]),
+    };
+
+    for (const format of ['stream', 'file'] as const) {
+        test(`round-trips through IPC ${format} format`, () => {
+            const original = tableFromArrays(input, schema);
+            const buffer = tableToIPC(original, format);
+            const table = tableFromIPC(buffer);
+
+            // Row and column counts
+            expect(table.numRows).toBe(3);
+            expect(table.numCols).toBe(3);
+
+            // Field ordering matches schema (not input key order)
+            expect(table.schema.fields[0].name).toBe('b');
+            expect(table.schema.fields[1].name).toBe('a');
+            expect(table.schema.fields[2].name).toBe('c');
+
+            // Types match schema-specified types (IPC reconstructs base classes, so check typeId + properties)
+            const typeA = table.getChild('a')!.type;
+            expect(DataType.isInt(typeA)).toBe(true);
+            expect((typeA as any).bitWidth).toBe(32);
+
+            const typeB = table.getChild('b')!.type;
+            expect(typeB.typeId).toBe(Type.Utf8);
+
+            const typeC = table.getChild('c')!.type;
+            expect(DataType.isInt(typeC)).toBe(true);
+            expect((typeC as any).bitWidth).toBe(8);
+
+            // Schema-level metadata
+            expect(table.schema.metadata.get('source')).toBe('test');
+
+            // Field-level metadata
+            const aField = table.schema.fields.find(f => f.name === 'a')!;
+            expect(aField.metadata.get('unit')).toBe('meters');
+
+            // Nullability and null counts
+            expect(aField.nullable).toBe(true);
+            expect(table.getChild('a')!.nullCount).toBe(1);
+
+            // Data values
+            const colA = table.getChild('a')!;
+            expect(colA.get(0)).toBe(1);
+            expect(colA.get(1)).toBeNull();
+            expect(colA.get(2)).toBe(3);
+
+            expect(table.getChild('b')!.get(0)).toBe('x');
+            expect(table.getChild('b')!.get(1)).toBe('y');
+            expect(table.getChild('b')!.get(2)).toBe('z');
+
+            // TypedArray coercion: Float32Array input → Int8 output
+            const colC = table.getChild('c')!;
+            expect(colC.get(0)).toBe(10);
+            expect(colC.get(1)).toBe(20);
+            expect(colC.get(2)).toBe(30);
+        });
+    }
+});
 
 describe('tableFromJSON()', () => {
     test(`creates table from array of objects`, () => {


### PR DESCRIPTION
## What's Changed

Allow callers to pass an explicit `Schema` to `tableFromArrays()` and a new   `recordBatchFromArrays()` function, giving control over column types, ordering, nullability, and metadata instead of relying solely on type inference.

Also adds a fast path in `vectorFromArray` for `TypedArray`-to-typed-vector coercion with `BigInt` boundary validation.