### PR TITLE
fix: Fix missing Schema and Field classes from API Docs

### DIFF
--- a/typedoc.json
+++ b/typedoc.json
@@ -9,7 +9,6 @@
     "includeVersion": true,
     "exclude": [
         "src/fb/*.ts",
-        "src/bin/*.ts",
-        "src/ipc/metadata/message.ts"
+        "src/bin/*.ts"
     ]
 }


### PR DESCRIPTION
## What's Changed

This PR fixes an issue which causes `Schema` and `Field` to be excluded from the [public API docs](https://arrow.apache.org/js/current/modules/Arrow.node.html).

The root cause is that this `declare module` block causes these to register as an exclusion. Everything else in this file is already explicitly ignored, so the config level exclusion is not necessary.

```ts
// src/ipc/metadata/message.ts
declare module '../../schema' {
    namespace Field {
        export { encodeField as encode };
        export { decodeField as decode };
        export { fieldFromJSON as fromJSON };
    }
    namespace Schema {
        export { encodeSchema as encode };
        export { decodeSchema as decode };
        export { schemaFromJSON as fromJSON };
    }
}
```


Closes #181.
