### PR TITLE
fix: tableFromJSON and tableFromArrays crash on arrays of strings

### DIFF
--- a/src/factories.ts
+++ b/src/factories.ts
@@ -104,6 +104,30 @@ export function tableFromJSON<T extends Record<string, unknown>>(array: T[]): Ta
 }
 
 /** @ignore */
+// Like compareTypes, but ignores Dictionary IDs — which are auto-incremented on
+// every construction, so two separately-inferred Dictionary types for the same
+// data will always have different IDs even though they are structurally identical.
+// Recurses through List children and Struct field types for the same reason.
+function compareTypesForInference(a: dtypes.DataType, b: dtypes.DataType): boolean {
+    if (dtypes.DataType.isDictionary(a) && dtypes.DataType.isDictionary(b)) {
+        return a.isOrdered === b.isOrdered
+            && compareTypes(a.indices, b.indices)
+            && compareTypes(a.dictionary, b.dictionary);
+    }
+    if (dtypes.DataType.isList(a) && dtypes.DataType.isList(b)) {
+        return compareTypesForInference(a.children[0].type, b.children[0].type);
+    }
+    if (dtypes.DataType.isStruct(a) && dtypes.DataType.isStruct(b)) {
+        return a.children.length === b.children.length
+            && a.children.every((f, i) =>
+                f.name === b.children[i].name
+                && compareTypesForInference(f.type, b.children[i].type)
+            );
+    }
+    return compareTypes(a, b);
+}
+
+/** @ignore */
 function inferType<T extends readonly unknown[]>(values: T): JavaScriptArrayDataType<T>;
 function inferType(value: readonly unknown[]): dtypes.DataType {
     if (value.length === 0) { return new dtypes.Null; }
@@ -149,7 +173,7 @@ function inferType(value: readonly unknown[]): dtypes.DataType {
     } else if (arraysCount + nullsCount === value.length) {
         const array = value as Array<unknown>[];
         const childType = inferType(array[array.findIndex((ary) => ary != null)]);
-        if (array.every((ary) => ary == null || compareTypes(childType, inferType(ary)))) {
+        if (array.every((ary) => ary == null || compareTypesForInference(childType, inferType(ary)))) {
             return new dtypes.List(new Field('', childType, true));
         }
     } else if (objectsCount + nullsCount === value.length) {

--- a/test/unit/table/table-test.ts
+++ b/test/unit/table/table-test.ts
@@ -56,6 +56,22 @@ describe('tableFromArrays()', () => {
         expect(table.getChild('d')!.type).toBeInstanceOf(Dictionary);
         expect(table.getChild('e' as any)).toBeNull();
     });
+
+    test(`creates table from arrays of strings`, () => {
+        const table = tableFromArrays({ word: [['a', 'b'], ['c', 'd']] });
+        expect(table.numRows).toBe(2);
+        const word = table.getChild('word')!;
+        expect(word.get(0)!.toArray()).toEqual(['a', 'b']);
+        expect(word.get(1)!.toArray()).toEqual(['c', 'd']);
+    });
+
+    test(`creates table from arrays of objects containing strings`, () => {
+        const table = tableFromArrays({ customers: [{ names: ['joe'] }, { names: ['bob'] }] });
+        expect(table.numRows).toBe(2);
+        const customers = table.getChild('customers')!;
+        expect(customers.get(0)!.names.toArray()).toEqual(['joe']);
+        expect(customers.get(1)!.names.toArray()).toEqual(['bob']);
+    });
 });
 
 
@@ -77,5 +93,21 @@ describe('tableFromJSON()', () => {
         expect(table.getChild('a')!.type).toBeInstanceOf(Float64);
         expect(table.getChild('b')!.type).toBeInstanceOf(Bool);
         expect(table.getChild('c')!.type).toBeInstanceOf(Dictionary);
+    });
+
+    test(`handles arrays of strings`, () => {
+        const t1 = tableFromJSON([{ a: ['hi'] }]);
+        expect(t1.getChild('a')!.get(0)!.toArray()).toEqual(['hi']);
+
+        const t2 = tableFromJSON([{ a: ['hi', 'there'] }]);
+        expect(t2.getChild('a')!.get(0)!.toArray()).toEqual(['hi', 'there']);
+    });
+
+    test(`handles nested objects containing strings`, () => {
+        const table = tableFromJSON([{ a: [{ b: 'hi' }, { b: 'there' }] }]);
+        expect(table.numRows).toBe(1);
+        const rows = table.getChild('a')!.get(0)!;
+        expect(rows.get(0)!.b).toBe('hi');
+        expect(rows.get(1)!.b).toBe('there');
     });
 });


### PR DESCRIPTION
## What's Changed

Applies a fix for type inference crashing on encountering an array of strings.

Added a `compareTypesForInference` helper that compares Dictionary types structurally, ignoring IDs. It recurses through List and Struct for nested cases. The public compareTypes is unchanged. ID equality still matters for IPC comparisons.


**Root cause:**

Strings infer to Dictionary<Utf8, Int32>, and every Dictionary construction auto-increments a global ID. The array homogeneity check in inferType calls compareTypes on separately inferred types, which requires matching IDs — so it always fails for string arrays.

Closes #86, #50
