### PR TITLE
docs: Add RecordBatch class to rendered docs

### DIFF
--- a/src/recordbatch.ts
+++ b/src/recordbatch.ts
@@ -46,7 +46,11 @@ export interface RecordBatch<T extends TypeMap = any> {
     [Symbol.isConcatSpreadable]: true;
 }
 
-/** @ignore */
+/**
+ * A RecordBatch is a collection of equal-length columns conforming to a
+ * particular {@link Schema}. A {@link Table} is composed of one or more
+ * RecordBatches.
+ */
 export class RecordBatch<T extends TypeMap = any> {
 
     /**


### PR DESCRIPTION
## What's Changed

https://github.com/apache/arrow-js/pull/390 will fix the docs (on next publish) to include `Schema` and `Field` classes in the docs, but `RecordBatch` was still not published.

This PR removes the `@ignore` tag, ensuring that the `RecordBatch` is generated and rendered:

<img width="1441" height="898" alt="image" src="https://github.com/user-attachments/assets/57a5efee-4ca7-4617-854a-9605beafd16b" />
